### PR TITLE
fix(ActionSheet): Dark mode support for ActionSheet

### DIFF
--- a/Anilibria/Classes/PresentationLayer/Modules/ActionSheet/ActionSheetViewController.swift
+++ b/Anilibria/Classes/PresentationLayer/Modules/ActionSheet/ActionSheetViewController.swift
@@ -59,12 +59,12 @@ final class ActionSheetViewController: BaseCollectionViewController {
             type: SectionBackgroundCollectionViewCompositionalLayout.self,
             configuration: conf
         ) { layout in
-            layout.backgroundColor = UIColor.white.withAlphaComponent(0.1)
+            layout.backgroundColor = .clear
             layout.cornerRadius = 4
             layout.backgroundInsets = .init(top: 0, left: 8, bottom: 0, right: 8)
         }
     }
-    
+
     override func setupStrings() {
         super.setupStrings()
         backButton.setTitle(L10n.Buttons.done, for: .normal)

--- a/Anilibria/Classes/PresentationLayer/Modules/ActionSheet/ActionSheetViewController.xib
+++ b/Anilibria/Classes/PresentationLayer/Modules/ActionSheet/ActionSheetViewController.xib
@@ -63,7 +63,7 @@
                                         <constraint firstAttribute="height" priority="751" constant="400" id="0NC-wK-Lml"/>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="10" id="ho6-Jm-uci"/>
                                     </constraints>
-                                    <blurEffect style="light"/>
+                                    <blurEffect style="systemMaterial"/>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                             <integer key="value" value="5"/>
@@ -100,7 +100,7 @@
                                                     <constraint firstItem="Apj-zN-056" firstAttribute="leading" secondItem="QCt-4q-80e" secondAttribute="leading" id="cC1-Af-Rho"/>
                                                 </constraints>
                                             </view>
-                                            <blurEffect style="light"/>
+                                            <blurEffect style="systemMaterial"/>
                                         </visualEffectView>
                                     </subviews>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Anilibria/Classes/PresentationLayer/Modules/ActionSheet/cells/ChoiceCell/ChoiceCell.xib
+++ b/Anilibria/Classes/PresentationLayer/Modules/ActionSheet/cells/ChoiceCell/ChoiceCell.xib
@@ -23,7 +23,7 @@
                     </view>
                     <view alpha="0.20000000000000001" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uDb-UA-PfK">
                         <rect key="frame" x="0.0" y="49" width="320" height="1"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="kym-vJ-dVS"/>
                         </constraints>
@@ -31,12 +31,12 @@
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ktM-M0-vDh">
                         <rect key="frame" x="16" y="14" width="262" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="textColor" systemColor="labelColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="A5X-3e-5Nr">
                         <rect key="frame" x="286" y="18" width="18" height="14.5"/>
-                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="tintColor" systemColor="labelColor"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="18" id="8WS-Du-5T9"/>
                             <constraint firstAttribute="height" constant="18" id="Qtm-ga-Jsz"/>

--- a/Anilibria/Classes/PresentationLayer/Modules/ActionSheet/cells/SheetHeaderView.swift
+++ b/Anilibria/Classes/PresentationLayer/Modules/ActionSheet/cells/SheetHeaderView.swift
@@ -36,7 +36,7 @@ class SheetHeaderView: UICollectionReusableView {
         contentView.spacing = 8
         contentView.alignment = .center
 
-        chevronView.tintColor = .Text.monoLight
+        chevronView.tintColor = .label
         chevronView.image = .System.Chevrone.right
         chevronView.heightAnchor.constraint(equalToConstant: 18).isActive = true
         chevronView.widthAnchor.constraint(equalToConstant: 10).isActive = true
@@ -45,11 +45,11 @@ class SheetHeaderView: UICollectionReusableView {
         contentView.addArrangedSubview(chevronView)
 
         titleLabel.font = UIFont.font(ofSize: 14, weight: .bold)
-        titleLabel.textColor = .Text.monoLight
+        titleLabel.textColor = .label
         contentView.addArrangedSubview(titleLabel)
 
         selectedValueLabel.font = UIFont.font(ofSize: 12, weight: .semibold)
-        selectedValueLabel.textColor = .Text.monoLight
+        selectedValueLabel.textColor = .secondaryLabel
         selectedValueLabel.setContentHuggingPriority(.required, for: .horizontal)
         selectedValueLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         selectedValueLabel.isHidden = true


### PR DESCRIPTION

Обновление визуального оформления ActionSheet для корректной поддержки темной темы и системных цветов:

*   **ActionSheetViewController**: Стиль `blurEffect` изменен с `light` на `systemMaterial` для адаптивности. Фон лейаута заменен на прозрачный.
*   **ChoiceCell**: Жестко заданные белые цвета текста, иконок и разделителей заменены на системные (`labelColor`, `separatorColor`), обеспечивая читаемость в обоих режимах интерфейса.
*   **SheetHeaderView**: Цвета заголовков и элементов управления переведены на использование системных динамических цветов (`label`, `secondaryLabel`).